### PR TITLE
Fix other creator types returned as author

### DIFF
--- a/src/modules/graphView.ts
+++ b/src/modules/graphView.ts
@@ -292,7 +292,14 @@ export default class GraphView {
   
   private getGraphByAuthorLink(items: Zotero.Item[]) {
     let getAuthors = (item: Zotero.Item) => {
-      return item.getCreators().filter(a => a.creatorTypeID == 8).map(a => {
+    let getAuthors = (item: Zotero.Item) => {
+      // creatorTypeID: 8 means "author" in Zotero creator types
+      const AUTHOR_CREATOR_TYPE_ID = 8
+      return item.getCreators()
+        .filter(a => a.creatorTypeID === AUTHOR_CREATOR_TYPE_ID)
+        .map(a => `${a.firstName || ""} ${a.lastName || ""}`.trim())
+        .filter(name => name.length > 0)
+    }
         return `${a.firstName} ${a.lastName}`
       })
     }

--- a/src/modules/graphView.ts
+++ b/src/modules/graphView.ts
@@ -292,7 +292,7 @@ export default class GraphView {
   
   private getGraphByAuthorLink(items: Zotero.Item[]) {
     let getAuthors = (item: Zotero.Item) => {
-      return item.getCreators().map(a => {
+      return item.getCreators().filter(a => a.creatorTypeID == 8).map(a => {
         return `${a.firstName} ${a.lastName}`
       })
     }


### PR DESCRIPTION
Author graph include wrong link of other creator types (e.g. editor). This lead to wrong link between papers doesn't share any author but published in the same journal/procceeding as the editors are the same. The error located in the function `getAuthors` which get more than authors. With one more filter on creator type (author is 8), this could be fixed.